### PR TITLE
Add support for slack team

### DIFF
--- a/Main.coffee
+++ b/Main.coffee
@@ -15,12 +15,16 @@ properties = [
   {
     name: "email"
     validator: /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-    warning: "Email is invali"
+    warning: "Email is invalid"
   }
   {
     message: "Enter your password (will be hidden)"
     name: "password"
     hidden: true
+  }
+  {
+    message: "Enter your Slack Team"
+    name: "team"
   }
 ]
 
@@ -56,6 +60,7 @@ prompt.get properties, (err, result) ->
       path.join(__dirname, "Scrape.coffee"),
       result.email,
       result.password,
+      result.team,
       files.join("...")
     ]
 

--- a/Scrape.coffee
+++ b/Scrape.coffee
@@ -4,7 +4,7 @@ casper = require("casper").create(
 args = casper.cli.args
 #require("utils").dump(casper.cli.args);
 
-email = password = null
+email = password = team = null
 files = []
 
 if args.length < 3
@@ -13,11 +13,12 @@ if args.length < 3
 else
   email = args[0]
   password = args[1]
-  files = args[2].split("...")
+  team = args[2]
+  files = args[3].split("...")
 
-casper.start "http://slack.com/signin", ->
+casper.start "http://#{team}.slack.com/signin", ->
 
-  @fill "form[action=\"/signin\"]",
+  @fill "form[action=\"/\"]",
     email: email
   , true
 


### PR DESCRIPTION
If you have multiple slack teams per email address, script will fail as,
you arrive at a signin page that specifies which slack team you need to
sign in to.

This adds functionality for specifying a slack team to auth to.
