### PR TITLE
Add coffee-script dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "prompt": "~0.2.13",
     "casperjs": "~1.1.0-beta3",
+    "coffee-script": "~1.10.0",
     "walk": "~2.3.3"
   },
   "devDependencies": {},


### PR DESCRIPTION
If it's not there, `make run` crashes with the following error:

```
./node_modules/coffee-script/bin/coffee Main.coffee
make: ./node_modules/coffee-script/bin/coffee: No such file or directory
make: *** [run] Error 1
```
